### PR TITLE
chore: Make a single library containing both binary targets

### DIFF
--- a/build-cap
+++ b/build-cap
@@ -67,11 +67,7 @@ let package = Package(
     products: [
         .library(
             name: "Capacitor",
-            targets: ["Capacitor"]
-        ),
-        .library(
-            name: "Cordova",
-            targets: ["Cordova"]
+            targets: ["Capacitor", "Cordova"]
         ),
     ],
     dependencies: [],


### PR DESCRIPTION
chore: Make a single library containing both binary targets instead of a 1:1 library/binaryTarget relationship.