### PR TITLE
docs(README): remove "experimental" from heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Experimental Swift Package Manager Support for Capacitor
+# Swift Package Manager Support for Capacitor
 
 This repo is for hosting binary xcframework releases of Capacitor and CapacitorCordova for SPM support.


### PR DESCRIPTION
This fixes the heading missed in https://github.com/ionic-team/capacitor-swift-pm/pull/30