### PR TITLE
ci: select xcode version based on release-version

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -18,7 +18,12 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
+      - run: |
+          if [[ "${{ inputs.release-version }}" =~ ^7\. ]]; then
+            sudo xcode-select --switch /Applications/Xcode_16.2.app
+          else
+            sudo xcode-select --switch /Applications/Xcode_26.0.app
+          fi
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: brew install ghr


### PR DESCRIPTION
Should address #33 (after we make a new 7.x patch release of capacitor)